### PR TITLE
add vscode commands for groups and snippets

### DIFF
--- a/applications/vscode.js
+++ b/applications/vscode.js
@@ -1,0 +1,16 @@
+/*Move between groups when multiple groups are set up in the window*/
+serenade.app("vscode").command("group <%direction%>", async (api, matches) => {
+    api.pressKey("k",["control"]);
+    api.pressKey(`${matches.direction}`,["control"]);
+});
+
+/*Insert a snippet (from VSCode or an extension) at the current position.
+It can be edited using Serenade's "system" command. The first match in the list
+of snippets is the snippet actually written in the document.*/
+serenade.app("vscode").command("snippet <%name%>", async (api, matches) => {
+    api.evaluateInPlugin("editor.action.insertSnippet");
+    setTimeout(function() {
+        api.typeText(matches.name);
+        api.pressKey("enter");
+    }, 500);
+});


### PR DESCRIPTION
Motivation behind these commands:
- The **group** command allows to navigate in VSCode when multiple groups are setup, as the tab command can't handle multiple groups. The direction is given as a parameter : up, down, left, right.
- The **snippet** command allows to handle all VSCode snippets, both built-in and from extensions. It allows partial snippet support for any file edited in VSCode (so non supported languages as well), in addition to be able to use any third party snippet. You can navigate a snippet by using "tab" and "system" commands. Using "insert" will break snippet navigation however.